### PR TITLE
Renaming p_drop_hidden and p_drop_input to p_keep_ for consistency

### DIFF
--- a/4_modern_net.py
+++ b/4_modern_net.py
@@ -7,14 +7,14 @@ def init_weights(shape):
     return tf.Variable(tf.random_normal(shape, stddev=0.01))
 
 
-def model(X, w_h, w_h2, w_o, p_drop_input, p_drop_hidden): # this network is the same as the previous one except with an extra hidden layer + dropout
-    X = tf.nn.dropout(X, p_drop_input)
+def model(X, w_h, w_h2, w_o, p_keep_input, p_keep_hidden): # this network is the same as the previous one except with an extra hidden layer + dropout
+    X = tf.nn.dropout(X, p_keep_input)
     h = tf.nn.relu(tf.matmul(X, w_h))
 
-    h = tf.nn.dropout(h, p_drop_hidden)
+    h = tf.nn.dropout(h, p_keep_hidden)
     h2 = tf.nn.relu(tf.matmul(h, w_h2))
 
-    h2 = tf.nn.dropout(h2, p_drop_hidden)
+    h2 = tf.nn.dropout(h2, p_keep_hidden)
 
     return tf.matmul(h2, w_o)
 


### PR DESCRIPTION
The `p_drop_` prefix was used in the `model()` function in `4_modern_net.py`, but `p_keep_` was used in the initialization and while training the model. This could lead to confusion – the [docs](http://tensorflow.org/api_docs/python/nn.md#dropout) describe the variable as `keep_prob` (as does `5_`), so I changed the names to `p_keep_` for consistency.

```
keep_prob: A Python float. The probability that each element is kept.
```