### PR TITLE
Added simple lstm example following other example styles.

### DIFF
--- a/6_lstm.py
+++ b/6_lstm.py
@@ -1,0 +1,91 @@
+#Inspired by https://github.com/aymericdamien/TensorFlow-Examples/blob/master/examples/3%20-%20Neural%20Networks/recurrent_network.py
+import tensorflow as tf
+from tensorflow.models.rnn import rnn, rnn_cell
+
+import numpy as np
+import input_data
+
+# configuration
+#                        O * W + b -> 10 labels for each image, O[? 28], W[28 10], B[10]
+#                       ^ (O: output 28 vec from 28 vec input)
+#                       |
+#      +-+  +-+       +--+
+#      |1|->|2|-> ... |28| time_step_size = 28
+#      +-+  +-+       +--+
+#       ^    ^    ...  ^
+#       |    |         |
+# img1:[28] [28]  ... [28]
+# img2:[28] [28]  ... [28]
+# img3:[28] [28]  ... [28]
+# ...
+# img128 or img256 (batch_size or test_size 256)
+#      each input size = input_vec_size=lstm_size=28
+
+# configuration variables
+input_vec_size = lstm_size = 28
+time_step_size = 28
+
+batch_size = 128
+test_size=256
+
+def init_weights(shape):
+    return tf.Variable(tf.random_normal(shape, stddev=0.01))
+
+
+def model(X, W, B, init_state, lstm_size):
+    # X, input shape: (batch_size, input_vec_size, time_step_size)
+    XT = tf.transpose(X, [1, 0, 2])  # permute time_step_size and batch_size
+    # XT shape: (input_vec_size, batch_szie, time_step_size)
+    XR = tf.reshape(XT, [-1, lstm_size]) # each row has input for each lstm cell (lstm_size)
+    # XR shape: (input vec_size, batch_size)
+    X_split = tf.split(0, time_step_size, XR) # split them to time_step_size (28 arrays)
+    # Each array shape: (batch_size, input_vec_size)
+
+    # Make lstm with lstm_size (each input vector size)
+    lstm = rnn_cell.BasicLSTMCell(lstm_size, forget_bias=1.0)
+
+    # Get lstm cell output, time_step_size (28) arrays with lstm_size output: (batch_size, lstm_size)
+    outputs, states = rnn.rnn(lstm, X_split, initial_state=init_state)
+
+    # Linear activation
+    # Get the last output
+    return tf.matmul(outputs[-1], W) + B, lstm.state_size # State size to initialize the stat
+
+mnist = input_data.read_data_sets("MNIST_data/", one_hot=True)
+trX, trY, teX, teY = mnist.train.images, mnist.train.labels, mnist.test.images, mnist.test.labels
+trX = trX.reshape(-1, 28, 28)
+teX = teX.reshape(-1, 28, 28)
+
+# Tensorflow LSTM cell requires 2x n_hidden length (state & cell)
+init_state = tf.placeholder("float", [None, 2*lstm_size])
+
+X = tf.placeholder("float", [None, 28, 28])
+Y = tf.placeholder("float", [None, 10])
+
+# get lstm_size and output 10 labels
+W = init_weights([lstm_size, 10])
+B = init_weights([10])
+
+py_x, state_size = model(X, W, B, init_state, lstm_size)
+
+cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(py_x, Y))
+train_op = tf.train.RMSPropOptimizer(0.001, 0.9).minimize(cost)
+predict_op = tf.argmax(py_x, 1)
+
+sess = tf.Session()
+init = tf.initialize_all_variables()
+sess.run(init)
+
+for i in range(100):
+    for start, end in zip(range(0, len(trX), batch_size), range(batch_size, len(trX), batch_size)):
+        sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end],
+                                       init_state: np.zeros((batch_size, state_size))})
+    
+    test_indices = np.arange(len(teX)) # Get A Test Batch
+    np.random.shuffle(test_indices)
+    test_indices = test_indices[0:test_size]
+    
+    print i, np.mean(np.argmax(teY[test_indices], axis=1) ==
+                     sess.run(predict_op, feed_dict={X: teX[test_indices],
+                                                     Y: teY[test_indices],
+                                                     init_state: np.zeros((test_size, state_size))}))


### PR DESCRIPTION
Added a lstm example. I just added the model, and all the rest is basically the same as other examples.

This example is inspired by https://github.com/aymericdamien/TensorFlow-Examples/blob/master/examples/3%20-%20Neural%20Networks/recurrent_network.py, but much simplified.

This simple implementation yields decent results:

0 0.66796875
1 0.79296875
2 0.84765625
3 0.8984375
4 0.91796875
5 0.921875
6 0.95703125
7 0.953125
8 0.953125
9 0.95703125
10 0.96875
...
91 0.9609375
92 0.98046875
93 0.984375
94 0.98046875
95 0.984375
96 0.97265625
97 0.984375
98 0.98046875
99 0.98828125