### PR TITLE
Exhaust training set

### DIFF
--- a/02_logistic_regression.py
+++ b/02_logistic_regression.py
@@ -33,7 +33,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end]})
         print(i, np.mean(np.argmax(teY, axis=1) ==
                          sess.run(predict_op, feed_dict={X: teX, Y: teY})))

--- a/03_net.py
+++ b/03_net.py
@@ -35,7 +35,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end]})
         print(i, np.mean(np.argmax(teY, axis=1) ==
                          sess.run(predict_op, feed_dict={X: teX, Y: teY})))

--- a/04_modern_net.py
+++ b/04_modern_net.py
@@ -45,7 +45,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end],
                                           p_keep_input: 0.8, p_keep_hidden: 0.5})
         print(i, np.mean(np.argmax(teY, axis=1) ==

--- a/05_convolutional_net.py
+++ b/05_convolutional_net.py
@@ -66,7 +66,7 @@ with tf.Session() as sess:
 
     for i in range(100):
         training_batch = zip(range(0, len(trX), batch_size),
-                             range(batch_size, len(trX), batch_size))
+                             range(batch_size, len(trX)+1, batch_size))
         for start, end in training_batch:
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end],
                                           p_keep_conv: 0.8, p_keep_hidden: 0.5})

--- a/06_autoencoder.py
+++ b/06_autoencoder.py
@@ -50,7 +50,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             input_ = trX[start:end]
             mask_np = np.random.binomial(1, 1 - corruption_level, input_.shape)
             sess.run(train_op, feed_dict={X: input_, mask: mask_np})

--- a/07_lstm.py
+++ b/07_lstm.py
@@ -74,7 +74,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), batch_size), range(batch_size, len(trX), batch_size)):
+        for start, end in zip(range(0, len(trX), batch_size), range(batch_size, len(trX)+1, batch_size)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end]})
 
         test_indices = np.arange(len(teX))  # Get A Test Batch

--- a/09_tensorboard.py
+++ b/09_tensorboard.py
@@ -60,7 +60,7 @@ with tf.Session() as sess:
     tf.initialize_all_variables().run()
 
     for i in range(100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end],
                                           p_keep_input: 0.8, p_keep_hidden: 0.5})
         summary, acc = sess.run([merged, acc_op], feed_dict={X: teX, Y: teY,

--- a/10_save_restore_net.py
+++ b/10_save_restore_net.py
@@ -70,7 +70,7 @@ with tf.Session() as sess:
     print("Start from:", start)
 
     for i in range(start, 100):
-        for start, end in zip(range(0, len(trX), 128), range(128, len(trX), 128)):
+        for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end],
                                           p_keep_input: 0.8, p_keep_hidden: 0.5})
 


### PR DESCRIPTION
Previously, when the `len(trX)` is completely divisible by `batch_size`, the training skipped over the last batch because `end=len(trX)` would never occur. Corrected this and now the loop will go over the entire training set if `batch_size` can cleanly fit in.