### PR TITLE
remove an argument from feed_dict to make no ambiguities

### DIFF
--- a/02_logistic_regression.py
+++ b/02_logistic_regression.py
@@ -36,4 +36,4 @@ with tf.Session() as sess:
         for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end]})
         print(i, np.mean(np.argmax(teY, axis=1) ==
-                         sess.run(predict_op, feed_dict={X: teX, Y: teY})))
+                         sess.run(predict_op, feed_dict={X: teX})))

--- a/03_net.py
+++ b/03_net.py
@@ -38,4 +38,4 @@ with tf.Session() as sess:
         for start, end in zip(range(0, len(trX), 128), range(128, len(trX)+1, 128)):
             sess.run(train_op, feed_dict={X: trX[start:end], Y: trY[start:end]})
         print(i, np.mean(np.argmax(teY, axis=1) ==
-                         sess.run(predict_op, feed_dict={X: teX, Y: teY})))
+                         sess.run(predict_op, feed_dict={X: teX})))


### PR DESCRIPTION
When I was first learning the code, I feel frustrated because Y: teY is assigned to feed_dict and I think predict_op doesn't need this argument. So I changed it.