### PR TITLE
Change 01_linear_regression.py for new version of TensorFlow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
   - pip install matplotlib
   # install TensorFlow from https://storage.googleapis.com/tensorflow/
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.1-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp34-cp34m-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.1-cp34-cp34m-linux_x86_64.whl;
     fi
 script:
   - sed -i -- 's/range(100)/range(1)/g' ??_*.py # change range to 1 for quick testing

--- a/01_linear_regression.py
+++ b/01_linear_regression.py
@@ -24,7 +24,7 @@ train_op = tf.train.GradientDescentOptimizer(0.01).minimize(cost) # construct an
 # Launch the graph in a session
 with tf.Session() as sess:
     # you need to initialize variables (in this case just variable W)
-    tf.initialize_all_variables().run()
+    tf.global_variables_initializer().run()
 
     for i in range(100):
         for (x, y) in zip(trX, trY):


### PR DESCRIPTION
When I run 01_linear_regression.py in my pc, 
terminal says 
"WARNING:tensorflow:From 01_linear_regression.py:27 in <module>.: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead."
So, I changed tf.initialize_all_variables().run() to tf.global_variables_initializer().run()